### PR TITLE
feat: Add new metric: Semantic R-Precision (SemR-p)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
+# KPEval: SemR-p 🛠️ 
+## (Fork for Semantic R-precision Implementation)
+
+**Note:** This repository is a fork of the official [KPEval toolkit](https://github.com/uclanlp/KPEval) by Wu, Yin, and Chang. The primary purpose of this fork is the development and testing of a new keyphrase evaluation metric, Semantic R-Precision (SemR-p).
+
+**Semantic R-precision**
+
+Semantic R-Precision (SemR-p) is a novel metric designed to jointly evaluate semantic relevance and ranking quality of reference agreement in keyphrase prediction. It builds upon the R-Precision framework by incorporating embedding-based semantic similarity for non-exact matches. This work aims to provide a more holistic assessment of keyphrase quality. 
+
+The implementation of SemR-p in this fork is intended for contribution back to the main KPEval toolkit. If you use SemR-p, please cite our [paper](https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation}):
+
+```
+@misc{VenturiniKinkel2024SemRp_preprint,
+  author    = {Venturini, Shamira and Kinkel, Steffen},
+  title     = {Meaning in Order, Order in Meaning: {S}emantic {R}-precision for Keyphrase Evaluation},
+  year      = {2025},
+  howpublished = {ResearchGate preprint},
+  note      = {Preprint available online},
+  url       = {https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation},
+  doi       = {10.13140/RG.2.2.31841.83044}
+}
+```
+
+### Modifications in this Fork:
+
+1.  **Added SemR-p Metric Implementation:**
+
+SemR-p was integrated into the existing `SemanticMatchingMetric` class alongside SemP, SemR, and SemF1 (within `metrics/semantic_matching_metric.py`): This integration leverages the same core phrase-level semantic similarity calculation (using Sentence Transformer `uclanlp/keyphrase-mpnet-v1`) already implemented for SemP/R/F1. This allows users interested in phrase-level semantic reference agreement to obtain both rank-agnostic scores (SemP/R/F1) and a rank-aware score (SemR-p) simultaneously by running the `semantic_matching` metric group, without the overhead of loading the embedding model twice or running separate evaluation scripts. SemR-p complements SemP/R/F1 by incorporating crucial ranking information (via the R-Precision framework) into the phrase-level semantic evaluation, offering a more complete picture of system-level semantic performance.
+
+2.  **Added macOS/CPU PyTorch Installation Instructions:**
+
+- Install torch. For macOS or CPU-only users (no CUDA):
+
+`pip install torch==1.13.1 torchvision torchaudio`
+
+
+
 # KPEval 🛠️
 
 KPEval is a toolkit for evaluating your keyphrase systems. 🎯 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,19 @@
+## --- PyTorch Installation ---
+
+# Option 1: For CUDA 11.7 (Uncomment these lines if using CUDA)
+# torch==1.13.1+cu117
+# torchvision==0.14.1+cu117
+# torchaudio==0.13.1
+
+# Option 2: For CPU / macOS (Uncomment these lines if NOT using CUDA)
+# torch==1.13.1
+# torchvision==0.14.1
+# torchaudio==0.13.1
+
+# --- End PyTorch ---
+
+
+# Other dependencies
 aiohttp==3.8.4
 aiosignal==1.3.1
 async-timeout==4.0.2
@@ -57,9 +73,6 @@ sentencepiece==0.1.99
 six==1.16.0
 threadpoolctl==3.1.0
 tokenizers==0.13.3
-torch==1.13.1+cu117
-torchaudio==0.13.1+cu117
-torchvision==0.14.1+cu117
 tqdm==4.65.0
 transformers==4.30.2
 typing_extensions==4.7.1


### PR DESCRIPTION
This pull request introduces Semantic R-Precision (SemR-p), a novel keyphrase evaluation metric designed to jointly assess semantic relevance and ranking quality. The metric, its motivation, and comprehensive evaluation are detailed in our paper: https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation.

**Summary of Changes:**

*   **Implemented Semantic R-Precision (SemR-p):**
    *   Added the core logic for SemR-p calculation within `metrics/semantic_matching_metric.py`.
    *   SemR-p builds on the R-Precision framework and SemP, SemR and SemF1, incorporating exact stem matching and semantic similarity scoring (using Sentence Transformers and averaging over `top_k` references).
    *   It is calculated when the `semantic_matching` metric group is run and uses the new `top_k` parameter (defaulting to 3) in the `.gin` config for `SemanticMatchingMetric`.
  *  **Added Data Retrieval Utility:**
    *   Included a new script `doc_retriever.py` to facilitate easy loading of source, target, and prediction data for specific document examples, by inputting `dataset`, `model`and, `doc_id`, aiding qualitative analysis.

**Design Rationale for SemR-p Integration:**

SemR-p was integrated into `SemanticMatchingMetric.py` to efficiently reuse the existing Sentence Transformer embedding model infrastructure and align with KPEval's current approach of grouping metrics with the same underlying semantic similarity calculation method.

**How to Use SemR-p (in this fork):**

*   When running `run_evaluation.py` with `metric_id='semantic_matching'`, SemR-p scores will be output under the key `semantic_r_precision`.
*   The `top_k` parameter for SemR-p can be configured in the `.gin` file within the `SemanticMatchingMetric.top_k` setting.

We believe these additions will be valuable to the KPEval toolkit and the broader keyphrase evaluation community.


