### PR TITLE
feat: add new metric: Semantic R-precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ SemR-p was integrated into the existing `SemanticMatchingMetric` class alongside
 
 `pip install torch==1.13.1 torchvision torchaudio`
 
+3.  **Added Data Retrieval Utility Script:** *(New Point)*
+    *   Included a new script `doc_retriever.py` that provides a function (`get_qualitative_data`) to easily load the source text, target keyphrases, and predicted keyphrases for a specific document index from the model_outputs folder.
+    *   This utility facilitates qualitative analysis and inspection of specific examples.
 
+
+-----------------------------
 
 # KPEval 🛠️
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
+# KPEval: SemR-p 🛠️ 
+## (Fork for Semantic R-precision Implementation)
+
+**Note:** This repository is a fork of the official [KPEval toolkit](https://github.com/uclanlp/KPEval) by Wu, Yin, and Chang. The primary purpose of this fork is the development and testing of a new keyphrase evaluation metric, Semantic R-Precision (SemR-p).
+
+**Semantic R-precision**
+
+Semantic R-Precision (SemR-p) is a novel metric designed to jointly evaluate semantic relevance and ranking quality of reference agreement in keyphrase prediction. It builds upon the R-Precision framework by incorporating embedding-based semantic similarity for non-exact matches. This work aims to provide a more holistic assessment of keyphrase quality. 
+
+The implementation of SemR-p in this fork is intended for contribution back to the main KPEval toolkit. If you use SemR-p, please cite our [paper](https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation}):
+
+```
+@misc{VenturiniKinkel2024SemRp_preprint,
+  author    = {Venturini, Shamira and Kinkel, Steffen},
+  title     = {Meaning in Order, Order in Meaning: {S}emantic {R}-precision for Keyphrase Evaluation},
+  year      = {2025},
+  howpublished = {ResearchGate preprint},
+  note      = {Preprint available online},
+  url       = {https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation},
+  doi       = {10.13140/RG.2.2.31841.83044}
+}
+```
+
+### Modifications in this Fork:
+
+1.  **Added SemR-p Metric Implementation:**
+
+SemR-p was integrated into the existing `SemanticMatchingMetric` class alongside SemP, SemR, and SemF1 (within `metrics/semantic_matching_metric.py`): This integration leverages the same core phrase-level semantic similarity calculation (using Sentence Transformer `uclanlp/keyphrase-mpnet-v1`) already implemented for SemP/R/F1. This allows users interested in phrase-level semantic reference agreement to obtain both rank-agnostic scores (SemP/R/F1) and a rank-aware score (SemR-p) simultaneously by running the `semantic_matching` metric group, without the overhead of loading the embedding model twice or running separate evaluation scripts. SemR-p complements SemP/R/F1 by incorporating crucial ranking information (via the R-Precision framework) into the phrase-level semantic evaluation, offering a more complete picture of system-level semantic performance.
+
+2.  **Added macOS/CPU PyTorch Installation Instructions:**
+
+- Install torch. For macOS or CPU-only users (no CUDA):
+
+`pip install torch==1.13.1 torchvision torchaudio`
+
+
+
 # KPEval 🛠️
 
 KPEval is a toolkit for evaluating your keyphrase systems. 🎯 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 **Semantic R-precision**
 
 Semantic R-Precision (SemR-p) is a novel metric designed to jointly evaluate semantic relevance and ranking quality of reference agreement in keyphrase prediction. It builds upon the R-Precision framework by incorporating embedding-based semantic similarity for non-exact matches. This work aims to provide a more holistic assessment of keyphrase quality. 
+SemR-p is output automatically with the other semantic metrics when using `semantic_matching` as metric_id in the evaluation function.
 
 The implementation of SemR-p in this fork is intended for contribution back to the main KPEval toolkit. If you use SemR-p, please cite our [paper](https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation}):
 
@@ -33,7 +34,7 @@ SemR-p was integrated into the existing `SemanticMatchingMetric` class alongside
 
 `pip install torch==1.13.1 torchvision torchaudio`
 
-3.  **Added Data Retrieval Utility Script:** *(New Point)*
+3.  **Added Data Retrieval Utility Script:**
     *   Included a new script `doc_retriever.py` that provides a function (`get_qualitative_data`) to easily load the source text, target keyphrases, and predicted keyphrases for a specific document index from the model_outputs folder.
     *   This utility facilitates qualitative analysis and inspection of specific examples.
 

--- a/configs/sample_config_kp20k.gin
+++ b/configs/sample_config_kp20k.gin
@@ -43,6 +43,7 @@ import metrics.sem_matching_metric
 SemanticMatchingMetric.model_name_or_path='uclanlp/keyphrase-mpnet-v1'
 SemanticMatchingMetric.similarity_threshold=0
 SemanticMatchingMetric.pooling_across_phrases='max'
+SemanticMatchingMetric.top_k=3
 
 
 # retrieval-based scores

--- a/configs/sample_config_kptimes.gin
+++ b/configs/sample_config_kptimes.gin
@@ -43,7 +43,7 @@ import metrics.sem_matching_metric
 SemanticMatchingMetric.model_name_or_path='uclanlp/keyphrase-mpnet-v1'
 SemanticMatchingMetric.similarity_threshold=0
 SemanticMatchingMetric.pooling_across_phrases='max'
-
+SemanticMatchingMetric.top_k=3
 
 # retrieval-based scores
 import metrics.retrieval_metric

--- a/doc_retriever.py
+++ b/doc_retriever.py
@@ -16,13 +16,13 @@ def get_qualitative_data(base_dir, dataset, model, doc_index):
         dict: A dictionary containing 'source', 'target', and 'predictions'
               for the specified document, or None if not found or an error occurs.
     """
-    # Construct the file path based on the provided structure
+    # Construct the file path
     file_name = f"{dataset}_hypotheses_linked.json"
     file_path = os.path.join(base_dir, dataset, model, file_name)
 
     print(f"Attempting to read document index {doc_index} from: {file_path}")
 
-    # Check if the file exists before trying to open it
+    # Check if the file exists
     if not os.path.exists(file_path):
         print(f"Error: File not found at {file_path}")
         return None
@@ -41,7 +41,6 @@ def get_qualitative_data(base_dir, dataset, model, doc_index):
                     break # Stop reading once the line is found
 
     except FileNotFoundError:
-        # This case is already handled by os.path.exists, but good practice
         print(f"Error: File not found during reading: {file_path}")
         return None
     except json.JSONDecodeError:
@@ -59,11 +58,10 @@ def get_qualitative_data(base_dir, dataset, model, doc_index):
     # Check if keys exist in the loaded data
     if not all(key in result_data for key in ['source', 'target', 'predictions']):
          print(f"Warning: Retrieved data for index {doc_index} might be missing expected keys ('source', 'target', 'predictions').")
-         # Return data anyway, let the caller handle missing keys if needed
 
     return result_data
 
-# --- Example Usage ---
+# ---  Usage ---
 
 project_root = "."
 base_output_dir = os.path.join(project_root, "model_outputs")

--- a/doc_retriever.py
+++ b/doc_retriever.py
@@ -1,0 +1,83 @@
+import json
+import os
+
+def get_qualitative_data(base_dir, dataset, model, doc_index):
+    """
+    Retrieves source text, target keyphrases, and predicted keyphrases
+    for a specific document from KPEval-style output files.
+
+    Args:
+        base_dir (str): The path to the 'model_outputs' directory.
+        dataset (str): The name of the dataset (e.g., 'kp20k').
+        model (str): The name of the model folder (e.g., '1_tf-idf').
+        doc_index (int): The 0-based index of the document to retrieve.
+
+    Returns:
+        dict: A dictionary containing 'source', 'target', and 'predictions'
+              for the specified document, or None if not found or an error occurs.
+    """
+    # Construct the file path based on the provided structure
+    file_name = f"{dataset}_hypotheses_linked.json"
+    file_path = os.path.join(base_dir, dataset, model, file_name)
+
+    print(f"Attempting to read document index {doc_index} from: {file_path}")
+
+    # Check if the file exists before trying to open it
+    if not os.path.exists(file_path):
+        print(f"Error: File not found at {file_path}")
+        return None
+
+    line_found = False
+    result_data = None
+
+    # Open and read the JSON Lines file line by line
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            for i, line in enumerate(f):
+                if i == doc_index:
+                    # Found the correct line, parse the JSON
+                    result_data = json.loads(line.strip())
+                    line_found = True
+                    break # Stop reading once the line is found
+
+    except FileNotFoundError:
+        # This case is already handled by os.path.exists, but good practice
+        print(f"Error: File not found during reading: {file_path}")
+        return None
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON on line {doc_index+1} in file {file_path}")
+        return None
+    except Exception as e:
+        print(f"An unexpected error occurred while reading file {file_path}: {e}")
+        return None
+
+
+    if not line_found:
+        print(f"Error: Document index {doc_index} not found in file {file_path}. File might be shorter than expected.")
+        return None
+
+    # Check if keys exist in the loaded data
+    if not all(key in result_data for key in ['source', 'target', 'predictions']):
+         print(f"Warning: Retrieved data for index {doc_index} might be missing expected keys ('source', 'target', 'predictions').")
+         # Return data anyway, let the caller handle missing keys if needed
+
+    return result_data
+
+# --- Example Usage ---
+
+project_root = "."
+base_output_dir = os.path.join(project_root, "model_outputs")
+
+dataset = 'kp20k'
+model = '19_gpt3-five-shot'
+doc_index = 569
+
+retrieved_data = get_qualitative_data(base_output_dir, dataset, model, doc_index)
+
+if retrieved_data:
+    print("\n--- Retrieved Data ---")
+    print(f"Source Text:\n{retrieved_data.get('source', 'N/A')}\n")
+    print(f"Target Keyphrases:\n{retrieved_data.get('target', 'N/A')}\n")
+    print(f"Predicted Keyphrases:\n{retrieved_data.get('predictions', 'N/A')}\n")
+else:
+    print(f"\nCould not retrieve data for the specified example.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,19 @@
+## --- PyTorch Installation ---
+
+# Option 1: For CUDA 11.7 (Uncomment these lines if using CUDA)
+# torch==1.13.1+cu117
+# torchvision==0.14.1+cu117
+# torchaudio==0.13.1
+
+# Option 2: For CPU / macOS (Uncomment these lines if NOT using CUDA)
+# torch==1.13.1
+# torchvision==0.14.1
+# torchaudio==0.13.1
+
+# --- End PyTorch ---
+
+
+# Other dependencies
 aiohttp==3.8.4
 aiosignal==1.3.1
 async-timeout==4.0.2
@@ -57,9 +73,6 @@ sentencepiece==0.1.99
 six==1.16.0
 threadpoolctl==3.1.0
 tokenizers==0.13.3
-torch==1.13.1+cu117
-torchaudio==0.13.1+cu117
-torchvision==0.14.1+cu117
 tqdm==4.65.0
 transformers==4.30.2
 typing_extensions==4.7.1


### PR DESCRIPTION
This pull request introduces Semantic R-Precision (SemR-p), a novel keyphrase evaluation metric designed to jointly assess semantic relevance and ranking quality. The metric, its motivation, and comprehensive evaluation are detailed in our paper: https://www.researchgate.net/publication/391552955_Meaning_in_Order_Order_in_Meaning_Semantic_R-precision_for_Keyphrase_Evaluation.

**Summary of Changes:**

*   **Implemented Semantic R-Precision (SemR-p):**
    *   Added the core logic for SemR-p calculation within `metrics/semantic_matching_metric.py`.
    *   SemR-p builds on the R-Precision framework and SemP, SemR and SemF1, incorporating exact stem matching and semantic similarity scoring (using Sentence Transformers and averaging over `top_k` references).
    *   It is calculated when the `semantic_matching` metric group is run and uses the new `top_k` parameter (defaulting to 3) in the `.gin` config for `SemanticMatchingMetric`.
  *  **Added Data Retrieval Utility:**
    *   Included a new script `doc_retriever.py` to facilitate easy loading of source, target, and prediction data for specific document examples, by inputting `dataset`, `model`and, `doc_id`, aiding qualitative analysis.

**Design Rationale for SemR-p Integration:**

SemR-p was integrated into `SemanticMatchingMetric.py` to efficiently reuse the existing Sentence Transformer embedding model infrastructure and align with KPEval's current approach of grouping metrics with the same underlying semantic similarity calculation method.

**How to Use SemR-p (in this fork):**

*   When running `run_evaluation.py` with `metric_id='semantic_matching'`, SemR-p scores will be output under the key `semantic_r_precision`.
*   The `top_k` parameter for SemR-p can be configured in the `.gin` file within the `SemanticMatchingMetric.top_k` setting.

We believe these additions will be valuable to the KPEval toolkit and the broader keyphrase evaluation community.


